### PR TITLE
HOSS2-181 - Fix no status scenarios

### DIFF
--- a/app/uk/gov/hmrc/homeofficesettledstatusstubs/services/StubDataService.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusstubs/services/StubDataService.scala
@@ -62,12 +62,6 @@ class StubDataService @Inject()(cc: ControllerComponents) extends BackendControl
           result = None,
           error = Some(StatusError("ERR_CONFLICT"))
         ))
-    case "ZL341566D" | "SP426589B" =>
-      Some(
-        StatusResponse(
-          correlationId,
-          result = None
-        ))
     case "TP991941C" =>
       Some(
         StatusResponse(

--- a/app/uk/gov/hmrc/homeofficesettledstatusstubs/stubdata/QATestStubData.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusstubs/stubdata/QATestStubData.scala
@@ -358,13 +358,6 @@ object QATestStubData {
     Nil
   )
 
-  val nevioSabina = StatusCheckResult(
-    "Nevio Sabina",
-    LocalDate.parse("9/10/1956", formatter),
-    "ESP",
-    Nil
-  )
-
   val results: Map[String, StatusCheckResult] = Map(
     "SP317690D" -> johnSmith1,
     "SP233073C" -> johnSmith3,
@@ -385,7 +378,6 @@ object QATestStubData {
     "SP921303A" -> johnSmith27,
     "SP323834A" -> johnSmith30,
     "SP352776C" -> johnSmith31,
-    "ZL341566D" -> nevioSabina,
     "SP426589B" -> johnSmith32
   )
 }

--- a/app/uk/gov/hmrc/homeofficesettledstatusstubs/stubdata/QATestStubData.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusstubs/stubdata/QATestStubData.scala
@@ -351,6 +351,20 @@ object QATestStubData {
     )
   )
 
+  val johnSmith32 = StatusCheckResult(
+    "John Smith",
+    LocalDate.parse("15/10/1971", formatter),
+    "ESP",
+    Nil
+  )
+
+  val nevioSabina = StatusCheckResult(
+    "Nevio Sabina",
+    LocalDate.parse("9/10/1956", formatter),
+    "ESP",
+    Nil
+  )
+
   val results: Map[String, StatusCheckResult] = Map(
     "SP317690D" -> johnSmith1,
     "SP233073C" -> johnSmith3,
@@ -370,6 +384,8 @@ object QATestStubData {
     "SP190793C" -> johnSmith26,
     "SP921303A" -> johnSmith27,
     "SP323834A" -> johnSmith30,
-    "SP352776C" -> johnSmith31
+    "SP352776C" -> johnSmith31,
+    "ZL341566D" -> nevioSabina,
+    "SP426589B" -> johnSmith32
   )
 }

--- a/app/uk/gov/hmrc/homeofficesettledstatusstubs/stubdata/TestStubData.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusstubs/stubdata/TestStubData.scala
@@ -423,6 +423,13 @@ object TestStubData {
     )
   )
 
+  val nevioSabina = StatusCheckResult(
+    "Nevio Sabina",
+    LocalDate.parse("9/10/1956", formatter),
+    "ESP",
+    Nil
+  )
+
   val results: Map[String, StatusCheckResult] = Map(
     "MZ006526D" -> ignacSarlota,
     "AB116565A" -> robinTens,
@@ -441,6 +448,7 @@ object TestStubData {
     "NJ288804C" -> lucySprag,
     "ZL048657A" -> jimmyBrown,
     "RR741495B" -> sarahSmith,
-    "RR741365B" -> peteWolf
+    "RR741365B" -> peteWolf,
+    "ZL341566D" -> nevioSabina
   )
 }

--- a/it/uk/gov/hmrc/homeofficesettledstatusstubs/controllers/HomeOfficeSettledStatusStubsControllerISpec.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatusstubs/controllers/HomeOfficeSettledStatusStubsControllerISpec.scala
@@ -149,11 +149,11 @@ class HomeOfficeSettledStatusStubsControllerISpec
           ))
       }
 
-      "respond with 200 if response empty" in {
+      "respond with 200 if statuses empty" in {
         ping.status.shouldBe(200)
 
         val result = publicFundsByNino(
-          s"""{"nino":"ZL341566D","givenName":"J","familyName":"Does","dateOfBirth":"2001-XX-31"}""")
+          s"""{"nino":"ZL341566D","givenName":"N","familyName":"Sabina","dateOfBirth":"1956-10-09"}""")
 
         result.status shouldBe 200
       }


### PR DESCRIPTION
The home office will always return a result object with a 200, and an error object with a 4xx or a 5xx. This scenario of them returning a result with no statuses should actually be represented by an empty status list, not the lack of a result.