### PR TITLE
Fix for Dynamic stubbing

### DIFF
--- a/app/uk/gov/hmrc/homeofficesettledstatusstubs/services/StubDataService.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusstubs/services/StubDataService.scala
@@ -86,7 +86,7 @@ class StubDataService @Inject() (cc: ControllerComponents) extends BackendContro
     val isExpired   = expired.contains("EX")
     val expiredDate = Some(if (isExpired) now.minusDays(1) else now.plusDays(1))
     StatusCheckResult(
-      "John Doe",
+      "Michael Makson",
       defaultDate,
       "AFG",
       List(


### PR DESCRIPTION
For Nino Search in relation to dynamic stubbing, some of the conditions are:

- The first character of the givenName must start with `M` to match the first character of the dynamic identifier
- The first three characters of the familyName must be `Mak` to match the first three characters of the familyName `Make` in the README

<img width="1661" alt="Screenshot 2023-05-02 at 14 44 41" src="https://user-images.githubusercontent.com/63714619/235689604-e561890b-aa1f-4cc4-bffe-a64dc8059e5f.png">

<img width="1665" alt="Screenshot 2023-05-02 at 14 45 08" src="https://user-images.githubusercontent.com/63714619/235689646-ae22f5dc-e072-461f-b177-83c4f42b49a4.png">
