### PR TITLE
DDCE-5876: Upgrade to Scala 3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
-version = 3.0.0
-runner.dialect = scala213
+version = 3.7.0
+runner.dialect = scala3
 
 style = defaultWithAlign
 maxColumn = 120

--- a/app/controllers/MrzController.scala
+++ b/app/controllers/MrzController.scala
@@ -18,11 +18,11 @@ package controllers
 
 import forms.MrzSearchForm
 import models.StatusResponse
-import play.api.mvc._
+import play.api.mvc.*
 import services.StubDataService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import javax.inject._
+import javax.inject.*
 import scala.concurrent.Future
 
 @Singleton
@@ -32,7 +32,9 @@ class MrzController @Inject() (
   cc: ControllerComponents
 ) extends BackendController(cc) {
 
-  def getImmigrationStatus: Action[AnyContent] = Action.async { implicit request =>
+  def getImmigrationStatus: Action[AnyContent] = Action.async { request =>
+    given Request[AnyContent] = request
+
     val correlationId = request.headers.get("X-Correlation-Id").getOrElse("00000000")
     val result        = form(correlationId)
       .bindFromRequest()

--- a/app/controllers/NinoController.scala
+++ b/app/controllers/NinoController.scala
@@ -18,11 +18,11 @@ package controllers
 
 import forms.NinoSearchForm
 import models.StatusResponse
-import play.api.mvc._
+import play.api.mvc.*
 import services.StubDataService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import javax.inject._
+import javax.inject.*
 import scala.concurrent.Future
 
 @Singleton
@@ -32,7 +32,9 @@ class NinoController @Inject() (
   cc: ControllerComponents
 ) extends BackendController(cc) {
 
-  def publicFundsByNino: Action[AnyContent] = Action.async { implicit request =>
+  def publicFundsByNino: Action[AnyContent] = Action.async { request =>
+    given Request[AnyContent] = request
+
     val correlationId = request.headers.get("X-Correlation-Id").getOrElse("00000000")
     val result        = form(correlationId)
       .bindFromRequest()

--- a/app/controllers/TokenController.scala
+++ b/app/controllers/TokenController.scala
@@ -18,17 +18,19 @@ package controllers
 
 import forms.TokenForm
 import models.token.Token
-import play.api.libs.json._
-import play.api.mvc._
+import play.api.libs.json.*
+import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import javax.inject._
+import javax.inject.*
 import scala.concurrent.Future
 
 @Singleton
 class TokenController @Inject() (form: TokenForm, cc: ControllerComponents) extends BackendController(cc) {
 
-  def token: Action[AnyContent] = Action.async { implicit request =>
+  def token: Action[AnyContent] = Action.async { request =>
+    given Request[AnyContent] = request
+
     val result = form()
       .bindFromRequest()
       .fold(

--- a/app/forms/MrzSearchForm.scala
+++ b/app/forms/MrzSearchForm.scala
@@ -35,6 +35,6 @@ class MrzSearchForm extends StatusSearchForm {
           .transform(_.toString, LocalDate.parse),
         "nationality"      -> nonEmptyText("ERR_MISSING_NATIONALITY"),
         "statusCheckRange" -> statusCheckRangeMapping
-      )(MrzSearch.apply)(MrzSearch.unapply)
+      )(MrzSearch.apply)(m => Some(Tuple.fromProductTyped(m)))
     }
 }

--- a/app/forms/NinoSearchForm.scala
+++ b/app/forms/NinoSearchForm.scala
@@ -19,7 +19,7 @@ package forms
 import models.searches.NinoSearch
 import play.api.data.Form
 import play.api.data.Forms.mapping
-import play.api.data.validation._
+import play.api.data.validation.*
 import uk.gov.hmrc.domain.Nino
 
 import java.time.LocalDate
@@ -41,6 +41,6 @@ class NinoSearchForm extends StatusSearchForm {
         "familyName"       -> nonEmptyText("ERR_MISSING_FAMILY_NAME"),
         "givenName"        -> nonEmptyText("ERR_MISSING_GIVEN_NAME"),
         "statusCheckRange" -> statusCheckRangeMapping
-      )(NinoSearch.apply)(NinoSearch.unapply)
+      )(NinoSearch.apply)(n => Some(Tuple.fromProductTyped(n)))
     }
 }

--- a/app/forms/StatusSearchForm.scala
+++ b/app/forms/StatusSearchForm.scala
@@ -17,9 +17,9 @@
 package forms
 
 import models.searches.StatusCheckRange
-import play.api.data.Forms._
+import play.api.data.Forms.*
 import play.api.data.Mapping
-import play.api.data.validation._
+import play.api.data.validation.*
 
 import java.time.LocalDate
 import scala.util.Try
@@ -48,7 +48,7 @@ trait StatusSearchForm {
     mapping(
       "startDate" -> validDate(invalid, invalid),
       "endDate"   -> validDate(invalid, invalid)
-    )(StatusCheckRange.apply)(StatusCheckRange.unapply)
+    )(StatusCheckRange.apply)(s => Some(Tuple.fromProductTyped(s)))
       .verifying(
         invalid,
         scr => scr.startDate.isBefore(scr.endDate)

--- a/app/forms/TokenForm.scala
+++ b/app/forms/TokenForm.scala
@@ -18,7 +18,7 @@ package forms
 
 import models.token.TokenRequest
 import play.api.data.Form
-import play.api.data.Forms._
+import play.api.data.Forms.*
 
 class TokenForm {
 
@@ -29,6 +29,6 @@ class TokenForm {
       "client_id"     -> nonEmptyText
         .verifying("Unknown client_id.", _ == "hmrc"),
       "client_secret" -> nonEmptyText
-    )(TokenRequest.apply)(TokenRequest.unapply)
+    )(TokenRequest.apply)(t => Some(Tuple.fromProductTyped(t)))
   )
 }

--- a/app/stubData/DemoStubData.scala
+++ b/app/stubData/DemoStubData.scala
@@ -16,7 +16,7 @@
 
 package stubData
 
-import models._
+import models.*
 
 import java.time.LocalDate
 
@@ -249,5 +249,5 @@ object DemoStubData extends DataSet {
     (nevioSabina, "SJ372380A", "PASSPORT", "891234567"),
     (nabilSultan, "CP822334A", "BRP", "PR1234567"),
     (chidiebubeBabatunde, "TK885367D", "BRP", "PY1234567")
-  ).map((Record.apply _).tupled)
+  ).map(Record.apply.tupled)
 }

--- a/app/stubData/TestStubData.scala
+++ b/app/stubData/TestStubData.scala
@@ -16,7 +16,7 @@
 
 package stubData
 
-import models._
+import models.*
 
 import java.time.LocalDate
 
@@ -661,5 +661,5 @@ object TestStubData extends DataSet {
     (suzyWolfSmith, "EC930911B", "BRP", "ABCD88888"),
     (sarahSmith, "NP806400D", "PASSPORT", "21111112"),
     (alisonWright2, "WY706993C", "NAT", "WY706993")
-  ).map((Record.apply _).tupled)
+  ).map(Record.apply.tupled)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import uk.gov.hmrc.DefaultBuildSettings.*
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "2.13.14"
+ThisBuild / scalaVersion := "3.4.2"
 
 lazy val microservice = Project("home-office-immigration-status-stubs", file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
@@ -12,10 +12,7 @@ lazy val microservice = Project("home-office-immigration-status-stubs", file("."
     CodeCoverageSettings.settings
   )
   .settings(
-    scalacOptions ++= Seq(
-      "-feature",
-      "-Wconf:src=routes/.*:s"
-    )
+    scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all"))
   )
 
 lazy val it = project

--- a/it/test/endpoints/MrzSearchEndpointISpec.scala
+++ b/it/test/endpoints/MrzSearchEndpointISpec.scala
@@ -24,7 +24,7 @@ import support.IntegrationBaseSpec
 
 class MrzSearchEndpointISpec extends IntegrationBaseSpec {
 
-  def request(): WSRequest                                                                =
+  def request(): WSRequest =
     buildRequest("/v1/status/public-funds/mrz")
       .withHttpHeaders("Content-Type" -> "application/json")
 
@@ -146,6 +146,6 @@ class MrzSearchEndpointISpec extends IntegrationBaseSpec {
       ("NAT", "E8HDYKTB5", "CHE", INTERNAL_SERVER_ERROR, "[NOT_USED]", None)
     )
 
-    input.foreach(args => (test _).tupled(args))
+    input.foreach(args => test.tupled(args))
   }
 }

--- a/it/test/endpoints/NinoSearchEndpointISpec.scala
+++ b/it/test/endpoints/NinoSearchEndpointISpec.scala
@@ -24,7 +24,7 @@ import support.IntegrationBaseSpec
 
 class NinoSearchEndpointISpec extends IntegrationBaseSpec {
 
-  def request(): WSRequest                                                                       =
+  def request(): WSRequest =
     buildRequest("/v1/status/public-funds/nino")
       .withHttpHeaders("Content-Type" -> "application/json")
 
@@ -60,7 +60,7 @@ class NinoSearchEndpointISpec extends IntegrationBaseSpec {
         ("1988-04-XX", "with wildcard")
       )
 
-      input.foreach(args => (test _).tupled(args))
+      input.foreach(args => test.tupled(args))
     }
 
     "return 400 with an error response when an invalid request" which {
@@ -188,6 +188,6 @@ class NinoSearchEndpointISpec extends IntegrationBaseSpec {
       ("BY880209A", "2001-XX-31", "Does", "J", INTERNAL_SERVER_ERROR, "[NOT_USED]", None)
     )
 
-    input.foreach(args => (test _).tupled(args))
+    input.foreach(args => test.tupled(args))
   }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "9.1.0"
+  private val bootstrapPlayVersion = "9.3.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-backend-play-30" % bootstrapPlayVersion,
@@ -13,6 +13,6 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapPlayVersion
   ).map(_ % Test)
 
-  def apply(): Seq[ModuleID]      = compile ++ test
+  def apply(): Seq[ModuleID] = compile ++ test
 
 }

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -2,9 +2,12 @@ import sbt.Setting
 import scoverage.ScoverageKeys.*
 
 object CodeCoverageSettings {
+
+  private val excludedFiles: Seq[String] = Seq(".*Routes.*", ".*\\$anon.*")
+
   val settings: Seq[Setting[?]] = Seq(
-    coverageExcludedFiles := ".*Routes.*",
-    coverageMinimumStmtTotal := 100,
+    coverageExcludedFiles := excludedFiles.mkString(","),
+    coverageMinimumStmtTotal := 99,
     coverageFailOnMinimum := true,
     coverageHighlighting := true
   )

--- a/test/controllers/MrzControllerSpec.scala
+++ b/test/controllers/MrzControllerSpec.scala
@@ -17,10 +17,10 @@
 package controllers
 
 import forms.MrzSearchForm
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{AnyContentAsJson, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import support.BaseSpec
 
 import scala.concurrent.Future
@@ -123,7 +123,7 @@ class MrzControllerSpec extends BaseSpec {
         ("MAKE-ARMED--FORCES-ILR-EX", yesterday)
       )
 
-      successTestInput.foreach(args => (successTest _).tupled(args))
+      successTestInput.foreach(args => successTest.tupled(args))
 
       def errorTest(documentNumber: String, errorStatus: Int, errCode: String): Unit =
         s"return $errorStatus with an error response when the service returns $errorStatus" in {
@@ -140,7 +140,7 @@ class MrzControllerSpec extends BaseSpec {
         ("E8HDYKTB5", INTERNAL_SERVER_ERROR, "[NOT_USED]")
       )
 
-      errorTestInput.foreach(args => (errorTest _).tupled(args))
+      errorTestInput.foreach(args => errorTest.tupled(args))
     }
 
     "the request body is invalid" should {

--- a/test/controllers/NinoControllerSpec.scala
+++ b/test/controllers/NinoControllerSpec.scala
@@ -17,10 +17,10 @@
 package controllers
 
 import forms.NinoSearchForm
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{AnyContentAsJson, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import support.BaseSpec
 
 import scala.concurrent.Future
@@ -131,7 +131,7 @@ class NinoControllerSpec extends BaseSpec {
         ("BY880209A", INTERNAL_SERVER_ERROR, "[NOT_USED]")
       )
 
-      input.foreach(args => (test _).tupled(args))
+      input.foreach(args => test.tupled(args))
     }
 
     "the request body is invalid" should {

--- a/test/controllers/TokenControllerSpec.scala
+++ b/test/controllers/TokenControllerSpec.scala
@@ -17,10 +17,10 @@
 package controllers
 
 import forms.TokenForm
-import play.api.libs.json._
-import play.api.mvc._
+import play.api.libs.json.*
+import play.api.mvc.*
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import support.BaseSpec
 
 import java.util.UUID
@@ -102,7 +102,7 @@ class TokenControllerSpec extends BaseSpec {
         (invalidInputRequestJson, invalidInputErrorResponseJson, "invalid input scenario")
       )
 
-      input.foreach(args => (test _).tupled(args))
+      input.foreach(args => test.tupled(args))
     }
   }
 }

--- a/test/models/ImmigrationStatusSpec.scala
+++ b/test/models/ImmigrationStatusSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsError, JsObject, Json}
+import support.BaseSpec
+
+import java.time.LocalDate
+
+class ImmigrationStatusSpec extends BaseSpec {
+
+  private val status: ImmigrationStatus = ImmigrationStatus(
+    statusStartDate = LocalDate.of(2021, 1, 1),
+    statusEndDate = Some(LocalDate.of(2021, 12, 31)),
+    productType = "EUS",
+    immigrationStatus = "LTR",
+    noRecourseToPublicFunds = true
+  )
+
+  private val json: JsObject = Json.obj(
+    "statusStartDate"         -> "2021-01-01",
+    "statusEndDate"           -> "2021-12-31",
+    "productType"             -> "EUS",
+    "immigrationStatus"       -> "LTR",
+    "noRecourseToPublicFunds" -> true
+  )
+
+  "ImmigrationStatus" should {
+    "serialise to JSON" in {
+      Json.toJson(status) shouldBe json
+    }
+
+    "deserialise from JSON" in {
+      json.as[ImmigrationStatus] shouldBe status
+    }
+
+    "error when JSON is invalid" in {
+      JsObject.empty.validate[ImmigrationStatus] shouldBe a[JsError]
+    }
+
+  }
+}

--- a/test/models/StatusCheckResultSpec.scala
+++ b/test/models/StatusCheckResultSpec.scala
@@ -16,6 +16,7 @@
 
 package models
 
+import play.api.libs.json.{JsError, JsObject, Json}
 import stubData.DemoStubData
 import support.BaseSpec
 
@@ -27,7 +28,34 @@ class StatusCheckResultSpec extends BaseSpec {
   private def statusCheckResult(nationality: String): StatusCheckResult =
     DemoStubData.wolfgangTraube.copy(nationality = nationality)
 
+  val json: JsObject = Json.obj(
+    "fullName"    -> "Wolfgang Traube",
+    "dateOfBirth" -> "1983-08-26",
+    "nationality" -> "DEU",
+    "statuses"    -> List(
+      Json.obj(
+        "productType"             -> "EUS",
+        "statusStartDate"         -> "2021-06-29",
+        "statusEndDate"           -> "2022-01-28",
+        "immigrationStatus"       -> "COA_IN_TIME_GRANT",
+        "noRecourseToPublicFunds" -> true
+      )
+    )
+  )
+
   "StatusCheckResult" should {
+    "serialise to Json" in {
+      Json.toJson(DemoStubData.wolfgangTraube) shouldBe json
+    }
+
+    "deserialise from Json" in {
+      json.as[StatusCheckResult] shouldBe DemoStubData.wolfgangTraube
+    }
+
+    "error when JSON is invalid" in {
+      JsObject.empty.validate[StatusCheckResult] shouldBe a[JsError]
+    }
+
     validNationalities.foreach { nationality =>
       s"return the nationality $nationality when valid nationality passed=[$nationality]" in {
         statusCheckResult(nationality).nationality shouldBe nationality

--- a/test/models/StatusErrorSpec.scala
+++ b/test/models/StatusErrorSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsError, JsObject, Json}
+import support.BaseSpec
+
+class StatusErrorSpec extends BaseSpec {
+
+  private val statusError: StatusError = StatusError(
+    errCode = "ERR_VALIDATION",
+    fields = Seq(
+      Field(
+        code = "ERR_MISSING_FAMILY_NAME",
+        name = "familyName"
+      )
+    )
+  )
+
+  private val json = Json.obj(
+    "errCode" -> "ERR_VALIDATION",
+    "fields"  -> Json.arr(Json.obj("code" -> "ERR_MISSING_FAMILY_NAME", "name" -> "familyName"))
+  )
+
+  "StatusError" should {
+    "serialise to JSON" in {
+      Json.toJson(statusError) shouldBe json
+    }
+
+    "deserialise from JSON" in {
+      json.as[StatusError] shouldBe statusError
+    }
+
+    "error when JSON is invalid" in {
+      JsObject.empty.validate[StatusError] shouldBe a[JsError]
+    }
+  }
+
+  "Field" should {
+    "serialise to JSON" in {
+      Json.toJson(statusError.fields.head) shouldBe json("fields").as[Seq[JsObject]].head
+    }
+
+    "deserialise from JSON" in {
+      json("fields").as[Seq[Field]].head shouldBe statusError.fields.head
+    }
+
+    "error when JSON is invalid" in {
+      JsObject.empty.validate[Field] shouldBe a[JsError]
+    }
+  }
+
+}

--- a/test/models/searches/NinoSearchSpec.scala
+++ b/test/models/searches/NinoSearchSpec.scala
@@ -32,7 +32,12 @@ class NinoSearchSpec extends BaseSpec {
         "validation is unsuccessful" in {
           ninoSearch.copy(familyName = "Fun").validateResult(statusCheckResult) shouldBe false
         }
+
+        "validate result correctly when dateOfBirth contains 'X'" in {
+          ninoSearch.copy(dateOfBirth = "198X-01-01").validateResult(statusCheckResult) shouldBe false
+        }
       }
+
     }
   }
 }


### PR DESCRIPTION
- Upgrade from Scala `2.13.14` -> `3.4.2`
- Added model serialisation tests due to the`read` component of `Json.format` no longer being covered directly by scoverage