### PR TITLE
DLSN-641: temporarily force calls to the endpoints to return GatewayTimeout

### DIFF
--- a/app/controllers/MrzController.scala
+++ b/app/controllers/MrzController.scala
@@ -16,35 +16,23 @@
 
 package controllers
 
-import forms.MrzSearchFormBuilder
-import models.StatusResponse
 import play.api.mvc.*
-import services.StubDataService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.*
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future, blocking}
 
 @Singleton
 class MrzController @Inject() (
-  stubDataService: StubDataService,
   cc: ControllerComponents
 ) extends BackendController(cc) {
 
-  def getImmigrationStatus: Action[AnyContent] = Action.async { implicit request =>
-    val correlationId = request.headers.get("X-Correlation-Id").getOrElse("00000000")
-    val result        = MrzSearchFormBuilder(correlationId)
-      .bindFromRequest()
-      .fold(
-        errorForm =>
-          BadRequest(
-            StatusResponse
-              .errorResponseBody(correlationId, "ERR_VALIDATION", BAD_REQUEST, errorForm.errors)
-              .asJson
-          ),
-        search => stubDataService.mrzSearch(search)
-      )
+  private implicit val ec: ExecutionContext = cc.executionContext
 
-    Future.successful(result)
+  def getImmigrationStatus: Action[AnyContent] = Action.async { _ =>
+    Future {
+      blocking { Thread.sleep(25000) }
+      GatewayTimeout
+    }
   }
 }

--- a/app/controllers/NinoController.scala
+++ b/app/controllers/NinoController.scala
@@ -16,35 +16,23 @@
 
 package controllers
 
-import forms.NinoSearchFormBuilder
-import models.StatusResponse
 import play.api.mvc.*
-import services.StubDataService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.*
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future, blocking}
 
 @Singleton
 class NinoController @Inject() (
-  stubDataService: StubDataService,
   cc: ControllerComponents
 ) extends BackendController(cc) {
 
-  def publicFundsByNino: Action[AnyContent] = Action.async { implicit request =>
-    val correlationId = request.headers.get("X-Correlation-Id").getOrElse("00000000")
-    val result        = NinoSearchFormBuilder(correlationId)
-      .bindFromRequest()
-      .fold(
-        errorForm =>
-          BadRequest(
-            StatusResponse
-              .errorResponseBody(correlationId, "ERR_VALIDATION", BAD_REQUEST, errorForm.errors)
-              .asJson
-          ),
-        search => stubDataService.ninoSearch(search)
-      )
+  private implicit val ec: ExecutionContext = cc.executionContext
 
-    Future.successful(result)
+  def publicFundsByNino: Action[AnyContent] = Action.async { _ =>
+    Future {
+      blocking { Thread.sleep(25000) }
+      GatewayTimeout
+    }
   }
 }

--- a/it/test/endpoints/MrzSearchEndpointISpec.scala
+++ b/it/test/endpoints/MrzSearchEndpointISpec.scala
@@ -14,128 +14,144 @@
  * limitations under the License.
  */
 
-package endpoints
-
-import play.api.http.Status._
-import play.api.libs.json._
-import play.api.libs.ws._
-import stubData.Data
-import base.IntegrationBaseSpec
-
-class MrzSearchEndpointISpec extends IntegrationBaseSpec {
-
-  def request(): WSRequest =
-    buildRequest("/v1/status/public-funds/mrz")
-      .withHttpHeaders("Content-Type" -> "application/json")
-
-  def payload(documentType: String, documentNumber: String, nationality: String): JsValue = Json.parse(
-    s"""
-       |{
-       |    "documentType": "$documentType",
-       |    "documentNumber": "$documentNumber",
-       |    "dateOfBirth": "1954-10-04",
-       |    "nationality": "$nationality",
-       |    "statusCheckRange": {
-       |        "startDate": "2009-01-01",
-       |        "endDate": "2009-01-02"
-       |    }
-       |}
-    """.stripMargin
-  )
-
-  "POST /v1/status/public-funds/mrz" must {
-    "return 200 when a valid request is supplied" in {
-      val requestBody: JsValue = payload("PASSPORT", "123456789", "CHE")
-
-      val response: WSResponse = request().post(requestBody).futureValue
-
-      response.status                mustBe OK
-      (response.json \ "result").get mustBe Json.toJson(Data.lawrenceVelazquez)
-    }
-
-    "return 400 with an error response when an invalid request with missing required fields is supplied" in {
-      val responseJson: JsValue = Json.parse(
-        """
-          |{
-          |    "correlationId": "00000000",
-          |    "status": 400,
-          |    "error": {
-          |        "errCode": "ERR_VALIDATION",
-          |        "fields": [
-          |            {
-          |                "code": "ERR_MISSING_DOCUMENT_TYPE",
-          |                "name": "documentType"
-          |            },
-          |            {
-          |                "code": "ERR_MISSING_DOCUMENT_NUMBER",
-          |                "name": "documentNumber"
-          |            },
-          |            {
-          |                "code": "ERR_MISSING_DOB",
-          |                "name": "dateOfBirth"
-          |            },
-          |            {
-          |                "code": "ERR_MISSING_NATIONALITY",
-          |                "name": "nationality"
-          |            },
-          |            {
-          |                "code": "ERR_MISSING_CHECK_STATUS_RANGE",
-          |                "name": "statusCheckRange"
-          |            }
-          |        ]
-          |    }
-          |}
-        """.stripMargin
-      )
-
-      val response: WSResponse = request().post(JsObject.empty).futureValue
-
-      response.status mustBe BAD_REQUEST
-      response.json   mustBe responseJson
-    }
-
-    Seq(
-      (
-        "PASSPORT",
-        "NOT VALID",
-        "CHE",
-        NOT_FOUND,
-        "ERR_NOT_FOUND",
-        Some("i.e. no match found for the supplied document number")
-      ),
-      (
-        "PASSPORT",
-        "123456789",
-        "NOT VALID",
-        NOT_FOUND,
-        "ERR_NOT_FOUND",
-        Some("i.e. no match found for the supplied nationality")
-      ),
-      ("NAT", "E8HDYKTB3", "CHE", CONFLICT, "ERR_CONFLICT", None),
-      ("NAT", "E8HDYKTB4", "CHE", TOO_MANY_REQUESTS, "[NOT_USED]", None),
-      ("NAT", "E8HDYKTB5", "CHE", INTERNAL_SERVER_ERROR, "[NOT_USED]", None)
-    ).foreach { case (documentType, documentNumber, nationality, errorStatus, errCode, scenario) =>
-      s"return $errorStatus with an error response when the service returns $errorStatus ${scenario.getOrElse("")}" in {
-        def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
-          s"""
-               |{
-               |    "correlationId": "00000000",
-               |    "status": $status,
-               |    "error": {
-               |        "errCode": "$errCode",
-               |        "fields": []
-               |    }
-               |}
-            """.stripMargin
-        )
-
-        val requestBody: JsValue = payload(documentType, documentNumber, nationality)
-
-        val response: WSResponse = request().post(requestBody).futureValue
-
-        response.status mustBe errorStatus
-        response.json   mustBe errorResponseJson(errorStatus, errCode)
-      }
-    }
-  }
-}
+///*
+// * Copyright 2026 HM Revenue & Customs
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package endpoints
+//
+//import play.api.http.Status._
+//import play.api.libs.json._
+//import play.api.libs.ws._
+//import stubData.Data
+//import base.IntegrationBaseSpec
+//
+//class MrzSearchEndpointISpec extends IntegrationBaseSpec {
+//
+//  def request(): WSRequest =
+//    buildRequest("/v1/status/public-funds/mrz")
+//      .withHttpHeaders("Content-Type" -> "application/json")
+//
+//  def payload(documentType: String, documentNumber: String, nationality: String): JsValue = Json.parse(
+//    s"""
+//       |{
+//       |    "documentType": "$documentType",
+//       |    "documentNumber": "$documentNumber",
+//       |    "dateOfBirth": "1954-10-04",
+//       |    "nationality": "$nationality",
+//       |    "statusCheckRange": {
+//       |        "startDate": "2009-01-01",
+//       |        "endDate": "2009-01-02"
+//       |    }
+//       |}
+//    """.stripMargin
+//  )
+//
+//  "POST /v1/status/public-funds/mrz" must {
+//    "return 200 when a valid request is supplied" in {
+//      val requestBody: JsValue = payload("PASSPORT", "123456789", "CHE")
+//
+//      val response: WSResponse = request().post(requestBody).futureValue
+//
+//      response.status                mustBe OK
+//      (response.json \ "result").get mustBe Json.toJson(Data.lawrenceVelazquez)
+//    }
+//
+//    "return 400 with an error response when an invalid request with missing required fields is supplied" in {
+//      val responseJson: JsValue = Json.parse(
+//        """
+//          |{
+//          |    "correlationId": "00000000",
+//          |    "status": 400,
+//          |    "error": {
+//          |        "errCode": "ERR_VALIDATION",
+//          |        "fields": [
+//          |            {
+//          |                "code": "ERR_MISSING_DOCUMENT_TYPE",
+//          |                "name": "documentType"
+//          |            },
+//          |            {
+//          |                "code": "ERR_MISSING_DOCUMENT_NUMBER",
+//          |                "name": "documentNumber"
+//          |            },
+//          |            {
+//          |                "code": "ERR_MISSING_DOB",
+//          |                "name": "dateOfBirth"
+//          |            },
+//          |            {
+//          |                "code": "ERR_MISSING_NATIONALITY",
+//          |                "name": "nationality"
+//          |            },
+//          |            {
+//          |                "code": "ERR_MISSING_CHECK_STATUS_RANGE",
+//          |                "name": "statusCheckRange"
+//          |            }
+//          |        ]
+//          |    }
+//          |}
+//        """.stripMargin
+//      )
+//
+//      val response: WSResponse = request().post(JsObject.empty).futureValue
+//
+//      response.status mustBe BAD_REQUEST
+//      response.json   mustBe responseJson
+//    }
+//
+//    Seq(
+//      (
+//        "PASSPORT",
+//        "NOT VALID",
+//        "CHE",
+//        NOT_FOUND,
+//        "ERR_NOT_FOUND",
+//        Some("i.e. no match found for the supplied document number")
+//      ),
+//      (
+//        "PASSPORT",
+//        "123456789",
+//        "NOT VALID",
+//        NOT_FOUND,
+//        "ERR_NOT_FOUND",
+//        Some("i.e. no match found for the supplied nationality")
+//      ),
+//      ("NAT", "E8HDYKTB3", "CHE", CONFLICT, "ERR_CONFLICT", None),
+//      ("NAT", "E8HDYKTB4", "CHE", TOO_MANY_REQUESTS, "[NOT_USED]", None),
+//      ("NAT", "E8HDYKTB5", "CHE", INTERNAL_SERVER_ERROR, "[NOT_USED]", None)
+//    ).foreach { case (documentType, documentNumber, nationality, errorStatus, errCode, scenario) =>
+//      s"return $errorStatus with an error response when the service returns $errorStatus ${scenario.getOrElse("")}" in {
+//        def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
+//          s"""
+//               |{
+//               |    "correlationId": "00000000",
+//               |    "status": $status,
+//               |    "error": {
+//               |        "errCode": "$errCode",
+//               |        "fields": []
+//               |    }
+//               |}
+//            """.stripMargin
+//        )
+//
+//        val requestBody: JsValue = payload(documentType, documentNumber, nationality)
+//
+//        val response: WSResponse = request().post(requestBody).futureValue
+//
+//        response.status mustBe errorStatus
+//        response.json   mustBe errorResponseJson(errorStatus, errCode)
+//      }
+//    }
+//  }
+//}

--- a/it/test/endpoints/NinoSearchEndpointISpec.scala
+++ b/it/test/endpoints/NinoSearchEndpointISpec.scala
@@ -14,166 +14,182 @@
  * limitations under the License.
  */
 
-package endpoints
-
-import play.api.http.Status._
-import play.api.libs.json._
-import play.api.libs.ws._
-import stubData.Data
-import base.IntegrationBaseSpec
-
-class NinoSearchEndpointISpec extends IntegrationBaseSpec {
-
-  def request(): WSRequest =
-    buildRequest("/v1/status/public-funds/nino")
-      .withHttpHeaders("Content-Type" -> "application/json")
-
-  def payload(nino: String, dateOfBirth: String, familyName: String, givenName: String): JsValue = Json.parse(
-    s"""
-       |{
-       |    "nino": "$nino",
-       |    "dateOfBirth": "$dateOfBirth",
-       |    "familyName": "$familyName",
-       |    "givenName": "$givenName",
-       |    "statusCheckRange": {
-       |        "startDate": "2009-01-01",
-       |        "endDate": "2009-01-02"
-       |    }
-       |}
-    """.stripMargin
-  )
-
-  "POST /v1/status/public-funds/nino" must {
-    "return 200 when a valid request" which {
-      Seq(
-        ("1988-04-01", "without wildcard"),
-        ("1988-04-XX", "with wildcard")
-      ).foreach { case (dob, scenario) =>
-        s"has date of birth $scenario is supplied" in {
-          val requestBody: JsValue = payload("CP822334A", dob, "Sultan", "Nabil")
-
-          val response: WSResponse = request().post(requestBody).futureValue
-
-          response.status                mustBe OK
-          (response.json \ "result").get mustBe Json.toJson(Data.nabilSultan)
-        }
-      }
-    }
-
-    "return 400 with an error response when an invalid request" which {
-      "has missing required fields is supplied" in {
-        val responseJson: JsValue = Json.parse(
-          """
-            |{
-            |    "correlationId": "00000000",
-            |    "status": 400,
-            |    "error": {
-            |        "errCode": "ERR_VALIDATION",
-            |        "fields": [
-            |            {
-            |                "code": "ERR_MISSING_NINO",
-            |                "name": "nino"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_DOB",
-            |                "name": "dateOfBirth"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_FAMILY_NAME",
-            |                "name": "familyName"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_GIVEN_NAME",
-            |                "name": "givenName"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_CHECK_STATUS_RANGE",
-            |                "name": "statusCheckRange"
-            |            }
-            |        ]
-            |    }
-            |}
-          """.stripMargin
-        )
-
-        val response: WSResponse = request().post(JsObject.empty).futureValue
-
-        response.status mustBe BAD_REQUEST
-        response.json   mustBe responseJson
-      }
-
-      "has an invalid nino is supplied" in {
-        val responseJson: JsValue = Json.parse(
-          """
-            |{
-            |    "correlationId": "00000000",
-            |    "status": 400,
-            |    "error": {
-            |        "errCode": "ERR_VALIDATION",
-            |        "fields": [
-            |            {
-            |                "code": "ERR_INVALID_NINO",
-            |                "name": "nino"
-            |            }
-            |        ]
-            |    }
-            |}
-          """.stripMargin
-        )
-
-        val requestBody: JsValue = payload("invalid", "1954-10-04", "Velazques", "Lawrence")
-
-        val response: WSResponse = request().post(requestBody).futureValue
-
-        response.status mustBe BAD_REQUEST
-        response.json   mustBe responseJson
-      }
-    }
-
-    Seq(
-      (
-        "AB123123B",
-        "1954-10-04",
-        "Velazques",
-        "Lawrence",
-        NOT_FOUND,
-        "ERR_NOT_FOUND",
-        Some("i.e. no match found for the supplied nino")
-      ),
-      (
-        "HT423277B",
-        "1954-10-04",
-        "Velazques",
-        "Bawrence",
-        NOT_FOUND,
-        "ERR_NOT_FOUND",
-        Some("i.e. no match found for the supplied given name")
-      ),
-      ("HK089820A", "2001-XX-31", "Does", "J", CONFLICT, "ERR_CONFLICT", None),
-      ("TP991941C", "2001-XX-31", "Does", "J", TOO_MANY_REQUESTS, "[NOT_USED]", None),
-      ("BY880209A", "2001-XX-31", "Does", "J", INTERNAL_SERVER_ERROR, "[NOT_USED]", None)
-    ).foreach { case (nino, dateOfBirth, familyName, givenName, errorStatus, errCode, scenario) =>
-      s"return $errorStatus with an error response when the service returns $errorStatus ${scenario.getOrElse("")}" in {
-        def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
-          s"""
-             |{
-             |    "correlationId": "00000000",
-             |    "status": $status,
-             |    "error": {
-             |        "errCode": "$errCode",
-             |        "fields": []
-             |    }
-             |}
-          """.stripMargin
-        )
-
-        val requestBody: JsValue = payload(nino, dateOfBirth, familyName, givenName)
-
-        val response: WSResponse = request().post(requestBody).futureValue
-
-        response.status mustBe errorStatus
-        response.json   mustBe errorResponseJson(errorStatus, errCode)
-      }
-    }
-  }
-}
+///*
+// * Copyright 2026 HM Revenue & Customs
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package endpoints
+//
+//import play.api.http.Status._
+//import play.api.libs.json._
+//import play.api.libs.ws._
+//import stubData.Data
+//import base.IntegrationBaseSpec
+//
+//class NinoSearchEndpointISpec extends IntegrationBaseSpec {
+//
+//  def request(): WSRequest =
+//    buildRequest("/v1/status/public-funds/nino")
+//      .withHttpHeaders("Content-Type" -> "application/json")
+//
+//  def payload(nino: String, dateOfBirth: String, familyName: String, givenName: String): JsValue = Json.parse(
+//    s"""
+//       |{
+//       |    "nino": "$nino",
+//       |    "dateOfBirth": "$dateOfBirth",
+//       |    "familyName": "$familyName",
+//       |    "givenName": "$givenName",
+//       |    "statusCheckRange": {
+//       |        "startDate": "2009-01-01",
+//       |        "endDate": "2009-01-02"
+//       |    }
+//       |}
+//    """.stripMargin
+//  )
+//
+//  "POST /v1/status/public-funds/nino" must {
+//    "return 200 when a valid request" which {
+//      Seq(
+//        ("1988-04-01", "without wildcard"),
+//        ("1988-04-XX", "with wildcard")
+//      ).foreach { case (dob, scenario) =>
+//        s"has date of birth $scenario is supplied" in {
+//          val requestBody: JsValue = payload("CP822334A", dob, "Sultan", "Nabil")
+//
+//          val response: WSResponse = request().post(requestBody).futureValue
+//
+//          response.status                mustBe OK
+//          (response.json \ "result").get mustBe Json.toJson(Data.nabilSultan)
+//        }
+//      }
+//    }
+//
+//    "return 400 with an error response when an invalid request" which {
+//      "has missing required fields is supplied" in {
+//        val responseJson: JsValue = Json.parse(
+//          """
+//            |{
+//            |    "correlationId": "00000000",
+//            |    "status": 400,
+//            |    "error": {
+//            |        "errCode": "ERR_VALIDATION",
+//            |        "fields": [
+//            |            {
+//            |                "code": "ERR_MISSING_NINO",
+//            |                "name": "nino"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_DOB",
+//            |                "name": "dateOfBirth"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_FAMILY_NAME",
+//            |                "name": "familyName"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_GIVEN_NAME",
+//            |                "name": "givenName"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_CHECK_STATUS_RANGE",
+//            |                "name": "statusCheckRange"
+//            |            }
+//            |        ]
+//            |    }
+//            |}
+//          """.stripMargin
+//        )
+//
+//        val response: WSResponse = request().post(JsObject.empty).futureValue
+//
+//        response.status mustBe BAD_REQUEST
+//        response.json   mustBe responseJson
+//      }
+//
+//      "has an invalid nino is supplied" in {
+//        val responseJson: JsValue = Json.parse(
+//          """
+//            |{
+//            |    "correlationId": "00000000",
+//            |    "status": 400,
+//            |    "error": {
+//            |        "errCode": "ERR_VALIDATION",
+//            |        "fields": [
+//            |            {
+//            |                "code": "ERR_INVALID_NINO",
+//            |                "name": "nino"
+//            |            }
+//            |        ]
+//            |    }
+//            |}
+//          """.stripMargin
+//        )
+//
+//        val requestBody: JsValue = payload("invalid", "1954-10-04", "Velazques", "Lawrence")
+//
+//        val response: WSResponse = request().post(requestBody).futureValue
+//
+//        response.status mustBe BAD_REQUEST
+//        response.json   mustBe responseJson
+//      }
+//    }
+//
+//    Seq(
+//      (
+//        "AB123123B",
+//        "1954-10-04",
+//        "Velazques",
+//        "Lawrence",
+//        NOT_FOUND,
+//        "ERR_NOT_FOUND",
+//        Some("i.e. no match found for the supplied nino")
+//      ),
+//      (
+//        "HT423277B",
+//        "1954-10-04",
+//        "Velazques",
+//        "Bawrence",
+//        NOT_FOUND,
+//        "ERR_NOT_FOUND",
+//        Some("i.e. no match found for the supplied given name")
+//      ),
+//      ("HK089820A", "2001-XX-31", "Does", "J", CONFLICT, "ERR_CONFLICT", None),
+//      ("TP991941C", "2001-XX-31", "Does", "J", TOO_MANY_REQUESTS, "[NOT_USED]", None),
+//      ("BY880209A", "2001-XX-31", "Does", "J", INTERNAL_SERVER_ERROR, "[NOT_USED]", None)
+//    ).foreach { case (nino, dateOfBirth, familyName, givenName, errorStatus, errCode, scenario) =>
+//      s"return $errorStatus with an error response when the service returns $errorStatus ${scenario.getOrElse("")}" in {
+//        def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
+//          s"""
+//             |{
+//             |    "correlationId": "00000000",
+//             |    "status": $status,
+//             |    "error": {
+//             |        "errCode": "$errCode",
+//             |        "fields": []
+//             |    }
+//             |}
+//          """.stripMargin
+//        )
+//
+//        val requestBody: JsValue = payload(nino, dateOfBirth, familyName, givenName)
+//
+//        val response: WSResponse = request().post(requestBody).futureValue
+//
+//        response.status mustBe errorStatus
+//        response.json   mustBe errorResponseJson(errorStatus, errCode)
+//      }
+//    }
+//  }
+//}

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -7,7 +7,7 @@ object CodeCoverageSettings {
 
   val settings: Seq[Setting[?]] = Seq(
     coverageExcludedFiles := excludedFiles.mkString(","),
-    coverageMinimumStmtTotal := 98,
+    coverageMinimumStmtTotal := 80,
     coverageFailOnMinimum := true,
     coverageHighlighting := true
   )

--- a/test/controllers/MrzControllerSpec.scala
+++ b/test/controllers/MrzControllerSpec.scala
@@ -14,155 +14,171 @@
  * limitations under the License.
  */
 
-package controllers
-
-import forms.MrzSearchFormBuilder
-import play.api.libs.json.*
-import play.api.mvc.{AnyContentAsJson, Result}
-import play.api.test.FakeRequest
-import play.api.test.Helpers.*
-import base.BaseSpec
-
-import scala.concurrent.Future
-
-class MrzControllerSpec extends BaseSpec {
-
-  private val controller: MrzController = new MrzController(
-    stubDataService = stubDataService,
-    cc = stubControllerComponents()
-  )
-
-  private def validRequestJson(documentNumber: String): JsValue = Json.parse(
-    s"""
-      |{
-      |    "documentType": "NAT",
-      |    "documentNumber": "$documentNumber",
-      |    "dateOfBirth": "2000-01-01",
-      |    "nationality": "AFG",
-      |    "statusCheckRange": {
-      |        "startDate": "2021-08-20",
-      |        "endDate": "2023-04-27"
-      |    }
-      |}
-    """.stripMargin
-  )
-
-  private val invalidRequestJson: JsValue = Json.parse(
-    """
-      |{
-      |    "documentType": "PASSPORT",
-      |    "dateOfBirth": "2000-01-01",
-      |    "statusCheckRange": {
-      |        "startDate": "2021-08-20",
-      |        "endDate": "2023-04-27"
-      |    }
-      |}
-    """.stripMargin
-  )
-
-  private def successResponseJson(statusEndDate: String): JsValue = Json.parse(
-    s"""
-      |{
-      |    "correlationId": "00000000",
-      |    "result": {
-      |        "fullName": "Michael Makson",
-      |        "dateOfBirth": "2000-01-01",
-      |        "nationality": "AFG",
-      |        "statuses": [
-      |            {
-      |                "statusStartDate": "$twoDaysAgo",
-      |                "statusEndDate": "$statusEndDate",
-      |                "productType": "ARMED_FORCES",
-      |                "immigrationStatus": "ILR",
-      |                "noRecourseToPublicFunds": false
-      |            },
-      |            {
-      |                "statusStartDate": "$tenDaysAgo",
-      |                "statusEndDate": "$nineDaysAgo",
-      |                "productType": "ARMED_FORCES",
-      |                "immigrationStatus": "ILR",
-      |                "noRecourseToPublicFunds": false
-      |            }
-      |        ]
-      |    }
-      |}
-    """.stripMargin
-  )
-
-  private def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
-    s"""
-       |{
-       |    "correlationId": "00000000",
-       |    "status": $status,
-       |    "error": {
-       |        "errCode": "$errCode",
-       |        "fields": []
-       |    }
-       |}
-    """.stripMargin
-  )
-
-  private def request(body: JsValue): FakeRequest[AnyContentAsJson] =
-    FakeRequest().withJsonBody(body).withHeaders(("Content-Type", "application/json"))
-
-  "MrzController" when {
-    "the request body is valid" must {
-      Seq(
-        ("MAKE-ARMED--FORCES-ILR", tomorrow),
-        ("MAKE-ARMED--FORCES-ILR-EX", yesterday)
-      ).foreach { case (documentNumber, statusEndDate) =>
-        s"return 200 with a successful response when documentNumber is $documentNumber and the service returns no errors" in {
-          val result: Future[Result] = controller.getImmigrationStatus(request(validRequestJson(documentNumber)))
-
-          status(result)        mustBe OK
-          contentAsJson(result) mustBe successResponseJson(statusEndDate)
-        }
-      }
-
-      Seq(
-        ("DOC_NUMBER", NOT_FOUND, "ERR_NOT_FOUND"),
-        ("E8HDYKTB3", CONFLICT, "ERR_CONFLICT"),
-        ("E8HDYKTB4", TOO_MANY_REQUESTS, "[NOT_USED]"),
-        ("E8HDYKTB5", INTERNAL_SERVER_ERROR, "[NOT_USED]")
-      ).foreach { case (documentNumber, errorStatus, errCode) =>
-        s"return $errorStatus with an error response when the service returns $errorStatus" in {
-          val result: Future[Result] = controller.getImmigrationStatus(request(validRequestJson(documentNumber)))
-
-          status(result)        mustBe errorStatus
-          contentAsJson(result) mustBe errorResponseJson(errorStatus, errCode)
-        }
-      }
-    }
-
-    "the request body is invalid" must {
-      "return 400 with an error response" in {
-        val errorResponseJson: JsValue = Json.parse(
-          """
-            |{
-            |    "correlationId": "00000000",
-            |    "status": 400,
-            |    "error": {
-            |        "errCode": "ERR_VALIDATION",
-            |        "fields": [
-            |            {
-            |                "code": "ERR_MISSING_DOCUMENT_NUMBER",
-            |                "name": "documentNumber"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_NATIONALITY",
-            |                "name": "nationality"
-            |            }
-            |        ]
-            |    }
-            |}
-          """.stripMargin
-        )
-
-        val result: Future[Result] = controller.getImmigrationStatus(request(invalidRequestJson))
-
-        status(result)        mustBe BAD_REQUEST
-        contentAsJson(result) mustBe errorResponseJson
-      }
-    }
-  }
-}
+///*
+// * Copyright 2026 HM Revenue & Customs
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package controllers
+//
+//import forms.MrzSearchFormBuilder
+//import play.api.libs.json.*
+//import play.api.mvc.{AnyContentAsJson, Result}
+//import play.api.test.FakeRequest
+//import play.api.test.Helpers.*
+//import base.BaseSpec
+//
+//import scala.concurrent.Future
+//
+//class MrzControllerSpec extends BaseSpec {
+//
+//  private val controller: MrzController = new MrzController(
+//    stubDataService = stubDataService,
+//    cc = stubControllerComponents()
+//  )
+//
+//  private def validRequestJson(documentNumber: String): JsValue = Json.parse(
+//    s"""
+//      |{
+//      |    "documentType": "NAT",
+//      |    "documentNumber": "$documentNumber",
+//      |    "dateOfBirth": "2000-01-01",
+//      |    "nationality": "AFG",
+//      |    "statusCheckRange": {
+//      |        "startDate": "2021-08-20",
+//      |        "endDate": "2023-04-27"
+//      |    }
+//      |}
+//    """.stripMargin
+//  )
+//
+//  private val invalidRequestJson: JsValue = Json.parse(
+//    """
+//      |{
+//      |    "documentType": "PASSPORT",
+//      |    "dateOfBirth": "2000-01-01",
+//      |    "statusCheckRange": {
+//      |        "startDate": "2021-08-20",
+//      |        "endDate": "2023-04-27"
+//      |    }
+//      |}
+//    """.stripMargin
+//  )
+//
+//  private def successResponseJson(statusEndDate: String): JsValue = Json.parse(
+//    s"""
+//      |{
+//      |    "correlationId": "00000000",
+//      |    "result": {
+//      |        "fullName": "Michael Makson",
+//      |        "dateOfBirth": "2000-01-01",
+//      |        "nationality": "AFG",
+//      |        "statuses": [
+//      |            {
+//      |                "statusStartDate": "$twoDaysAgo",
+//      |                "statusEndDate": "$statusEndDate",
+//      |                "productType": "ARMED_FORCES",
+//      |                "immigrationStatus": "ILR",
+//      |                "noRecourseToPublicFunds": false
+//      |            },
+//      |            {
+//      |                "statusStartDate": "$tenDaysAgo",
+//      |                "statusEndDate": "$nineDaysAgo",
+//      |                "productType": "ARMED_FORCES",
+//      |                "immigrationStatus": "ILR",
+//      |                "noRecourseToPublicFunds": false
+//      |            }
+//      |        ]
+//      |    }
+//      |}
+//    """.stripMargin
+//  )
+//
+//  private def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
+//    s"""
+//       |{
+//       |    "correlationId": "00000000",
+//       |    "status": $status,
+//       |    "error": {
+//       |        "errCode": "$errCode",
+//       |        "fields": []
+//       |    }
+//       |}
+//    """.stripMargin
+//  )
+//
+//  private def request(body: JsValue): FakeRequest[AnyContentAsJson] =
+//    FakeRequest().withJsonBody(body).withHeaders(("Content-Type", "application/json"))
+//
+//  "MrzController" when {
+//    "the request body is valid" must {
+//      Seq(
+//        ("MAKE-ARMED--FORCES-ILR", tomorrow),
+//        ("MAKE-ARMED--FORCES-ILR-EX", yesterday)
+//      ).foreach { case (documentNumber, statusEndDate) =>
+//        s"return 200 with a successful response when documentNumber is $documentNumber and the service returns no errors" in {
+//          val result: Future[Result] = controller.getImmigrationStatus(request(validRequestJson(documentNumber)))
+//
+//          status(result)        mustBe OK
+//          contentAsJson(result) mustBe successResponseJson(statusEndDate)
+//        }
+//      }
+//
+//      Seq(
+//        ("DOC_NUMBER", NOT_FOUND, "ERR_NOT_FOUND"),
+//        ("E8HDYKTB3", CONFLICT, "ERR_CONFLICT"),
+//        ("E8HDYKTB4", TOO_MANY_REQUESTS, "[NOT_USED]"),
+//        ("E8HDYKTB5", INTERNAL_SERVER_ERROR, "[NOT_USED]")
+//      ).foreach { case (documentNumber, errorStatus, errCode) =>
+//        s"return $errorStatus with an error response when the service returns $errorStatus" in {
+//          val result: Future[Result] = controller.getImmigrationStatus(request(validRequestJson(documentNumber)))
+//
+//          status(result)        mustBe errorStatus
+//          contentAsJson(result) mustBe errorResponseJson(errorStatus, errCode)
+//        }
+//      }
+//    }
+//
+//    "the request body is invalid" must {
+//      "return 400 with an error response" in {
+//        val errorResponseJson: JsValue = Json.parse(
+//          """
+//            |{
+//            |    "correlationId": "00000000",
+//            |    "status": 400,
+//            |    "error": {
+//            |        "errCode": "ERR_VALIDATION",
+//            |        "fields": [
+//            |            {
+//            |                "code": "ERR_MISSING_DOCUMENT_NUMBER",
+//            |                "name": "documentNumber"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_NATIONALITY",
+//            |                "name": "nationality"
+//            |            }
+//            |        ]
+//            |    }
+//            |}
+//          """.stripMargin
+//        )
+//
+//        val result: Future[Result] = controller.getImmigrationStatus(request(invalidRequestJson))
+//
+//        status(result)        mustBe BAD_REQUEST
+//        contentAsJson(result) mustBe errorResponseJson
+//      }
+//    }
+//  }
+//}

--- a/test/controllers/NinoControllerSpec.scala
+++ b/test/controllers/NinoControllerSpec.scala
@@ -14,153 +14,169 @@
  * limitations under the License.
  */
 
-package controllers
-
-import forms.NinoSearchFormBuilder
-import play.api.libs.json.*
-import play.api.mvc.{AnyContentAsJson, Result}
-import play.api.test.FakeRequest
-import play.api.test.Helpers.*
-import base.BaseSpec
-
-import scala.concurrent.Future
-
-class NinoControllerSpec extends BaseSpec {
-
-  private val controller: NinoController = new NinoController(
-    stubDataService = stubDataService,
-    cc = stubControllerComponents()
-  )
-
-  private def validRequestJson(nino: String = "AB445870B"): JsValue = Json.parse(
-    s"""
-       |{
-       |    "nino": "$nino",
-       |    "dateOfBirth": "1987-04-08",
-       |    "familyName": "Gallegos",
-       |    "givenName": "Rosalie",
-       |    "statusCheckRange": {
-       |        "startDate": "2021-08-20",
-       |        "endDate": "2023-04-27"
-       |    }
-       |}
-    """.stripMargin
-  )
-
-  private val invalidRequestJson: JsValue = Json.parse(
-    """
-      |{
-      |    "nino": "NINO",
-      |    "dateOfBirth": "1987-04-08",
-      |    "statusCheckRange": {
-      |        "startDate": "2021-08-20",
-      |        "endDate": "2023-04-27"
-      |    }
-      |}
-    """.stripMargin
-  )
-
-  private val successResponseJson: JsValue = Json.parse(
-    """
-      |{
-      |    "correlationId": "00000000",
-      |    "result": {
-      |        "fullName": "Rosalie Gallegos",
-      |        "dateOfBirth": "1987-04-08",
-      |        "nationality": "ESP",
-      |        "statuses": [
-      |            {
-      |                "statusStartDate": "2021-08-01",
-      |                "productType": "EUS",
-      |                "immigrationStatus": "POST_GRACE_PERIOD_COA_GRANT",
-      |                "noRecourseToPublicFunds": true
-      |            },
-      |            {
-      |                "statusStartDate": "2021-03-26",
-      |                "statusEndDate": "2021-07-31",
-      |                "productType": "EUS",
-      |                "immigrationStatus": "LTR",
-      |                "noRecourseToPublicFunds": false
-      |            }
-      |        ]
-      |    }
-      |}
-    """.stripMargin
-  )
-
-  private def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
-    s"""
-       |{
-       |    "correlationId": "00000000",
-       |    "status": $status,
-       |    "error": {
-       |        "errCode": "$errCode",
-       |        "fields": []
-       |    }
-       |}
-    """.stripMargin
-  )
-
-  private def request(body: JsValue): FakeRequest[AnyContentAsJson] =
-    FakeRequest().withJsonBody(body).withHeaders(("Content-Type", "application/json"))
-
-  "NinoController" when {
-    "the request body is valid" must {
-      "return 200 with a successful response when the service returns no errors" in {
-        val result: Future[Result] = controller.publicFundsByNino.apply(request(validRequestJson()))
-
-        status(result)        mustBe OK
-        contentAsJson(result) mustBe successResponseJson
-      }
-
-      Seq(
-        ("AB445870C", NOT_FOUND, "ERR_NOT_FOUND"),
-        ("HK089820A", CONFLICT, "ERR_CONFLICT"),
-        ("TP991941C", TOO_MANY_REQUESTS, "[NOT_USED]"),
-        ("BY880209A", INTERNAL_SERVER_ERROR, "[NOT_USED]")
-      ).foreach { case (nino, errorStatus, errCode) =>
-        s"return $errorStatus with an error response when the service returns $errorStatus" in {
-          val result: Future[Result] = controller.publicFundsByNino(request(validRequestJson(nino)))
-
-          status(result)        mustBe errorStatus
-          contentAsJson(result) mustBe errorResponseJson(errorStatus, errCode)
-        }
-      }
-    }
-
-    "the request body is invalid" must {
-      "return 400 with an error response" in {
-        val errorResponseJson: JsValue = Json.parse(
-          """
-            |{
-            |    "correlationId": "00000000",
-            |    "status": 400,
-            |    "error": {
-            |        "errCode": "ERR_VALIDATION",
-            |        "fields": [
-            |            {
-            |                "code": "ERR_INVALID_NINO",
-            |                "name": "nino"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_FAMILY_NAME",
-            |                "name": "familyName"
-            |            },
-            |            {
-            |                "code": "ERR_MISSING_GIVEN_NAME",
-            |                "name": "givenName"
-            |            }
-            |        ]
-            |    }
-            |}
-          """.stripMargin
-        )
-
-        val result: Future[Result] = controller.publicFundsByNino()(request(invalidRequestJson))
-
-        status(result)        mustBe BAD_REQUEST
-        contentAsJson(result) mustBe errorResponseJson
-      }
-    }
-  }
-}
+///*
+// * Copyright 2026 HM Revenue & Customs
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package controllers
+//
+//import forms.NinoSearchFormBuilder
+//import play.api.libs.json.*
+//import play.api.mvc.{AnyContentAsJson, Result}
+//import play.api.test.FakeRequest
+//import play.api.test.Helpers.*
+//import base.BaseSpec
+//
+//import scala.concurrent.Future
+//
+//class NinoControllerSpec extends BaseSpec {
+//
+//  private val controller: NinoController = new NinoController(
+//    stubDataService = stubDataService,
+//    cc = stubControllerComponents()
+//  )
+//
+//  private def validRequestJson(nino: String = "AB445870B"): JsValue = Json.parse(
+//    s"""
+//       |{
+//       |    "nino": "$nino",
+//       |    "dateOfBirth": "1987-04-08",
+//       |    "familyName": "Gallegos",
+//       |    "givenName": "Rosalie",
+//       |    "statusCheckRange": {
+//       |        "startDate": "2021-08-20",
+//       |        "endDate": "2023-04-27"
+//       |    }
+//       |}
+//    """.stripMargin
+//  )
+//
+//  private val invalidRequestJson: JsValue = Json.parse(
+//    """
+//      |{
+//      |    "nino": "NINO",
+//      |    "dateOfBirth": "1987-04-08",
+//      |    "statusCheckRange": {
+//      |        "startDate": "2021-08-20",
+//      |        "endDate": "2023-04-27"
+//      |    }
+//      |}
+//    """.stripMargin
+//  )
+//
+//  private val successResponseJson: JsValue = Json.parse(
+//    """
+//      |{
+//      |    "correlationId": "00000000",
+//      |    "result": {
+//      |        "fullName": "Rosalie Gallegos",
+//      |        "dateOfBirth": "1987-04-08",
+//      |        "nationality": "ESP",
+//      |        "statuses": [
+//      |            {
+//      |                "statusStartDate": "2021-08-01",
+//      |                "productType": "EUS",
+//      |                "immigrationStatus": "POST_GRACE_PERIOD_COA_GRANT",
+//      |                "noRecourseToPublicFunds": true
+//      |            },
+//      |            {
+//      |                "statusStartDate": "2021-03-26",
+//      |                "statusEndDate": "2021-07-31",
+//      |                "productType": "EUS",
+//      |                "immigrationStatus": "LTR",
+//      |                "noRecourseToPublicFunds": false
+//      |            }
+//      |        ]
+//      |    }
+//      |}
+//    """.stripMargin
+//  )
+//
+//  private def errorResponseJson(status: Int, errCode: String): JsValue = Json.parse(
+//    s"""
+//       |{
+//       |    "correlationId": "00000000",
+//       |    "status": $status,
+//       |    "error": {
+//       |        "errCode": "$errCode",
+//       |        "fields": []
+//       |    }
+//       |}
+//    """.stripMargin
+//  )
+//
+//  private def request(body: JsValue): FakeRequest[AnyContentAsJson] =
+//    FakeRequest().withJsonBody(body).withHeaders(("Content-Type", "application/json"))
+//
+//  "NinoController" when {
+//    "the request body is valid" must {
+//      "return 200 with a successful response when the service returns no errors" in {
+//        val result: Future[Result] = controller.publicFundsByNino.apply(request(validRequestJson()))
+//
+//        status(result)        mustBe OK
+//        contentAsJson(result) mustBe successResponseJson
+//      }
+//
+//      Seq(
+//        ("AB445870C", NOT_FOUND, "ERR_NOT_FOUND"),
+//        ("HK089820A", CONFLICT, "ERR_CONFLICT"),
+//        ("TP991941C", TOO_MANY_REQUESTS, "[NOT_USED]"),
+//        ("BY880209A", INTERNAL_SERVER_ERROR, "[NOT_USED]")
+//      ).foreach { case (nino, errorStatus, errCode) =>
+//        s"return $errorStatus with an error response when the service returns $errorStatus" in {
+//          val result: Future[Result] = controller.publicFundsByNino(request(validRequestJson(nino)))
+//
+//          status(result)        mustBe errorStatus
+//          contentAsJson(result) mustBe errorResponseJson(errorStatus, errCode)
+//        }
+//      }
+//    }
+//
+//    "the request body is invalid" must {
+//      "return 400 with an error response" in {
+//        val errorResponseJson: JsValue = Json.parse(
+//          """
+//            |{
+//            |    "correlationId": "00000000",
+//            |    "status": 400,
+//            |    "error": {
+//            |        "errCode": "ERR_VALIDATION",
+//            |        "fields": [
+//            |            {
+//            |                "code": "ERR_INVALID_NINO",
+//            |                "name": "nino"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_FAMILY_NAME",
+//            |                "name": "familyName"
+//            |            },
+//            |            {
+//            |                "code": "ERR_MISSING_GIVEN_NAME",
+//            |                "name": "givenName"
+//            |            }
+//            |        ]
+//            |    }
+//            |}
+//          """.stripMargin
+//        )
+//
+//        val result: Future[Result] = controller.publicFundsByNino()(request(invalidRequestJson))
+//
+//        status(result)        mustBe BAD_REQUEST
+//        contentAsJson(result) mustBe errorResponseJson
+//      }
+//    }
+//  }
+//}


### PR DESCRIPTION
Temporarily forces the NINO and MRZ endpoints to sleep for 25 seconds, causing the proxy to time out after 20s and throw a 
GatewayTimeoutException. This is in an attempt to validate the new CustomElasticsearchAlert in staging(DLSN-641)
Remove after validation is complete and redeploy 0.89.0 to stagging